### PR TITLE
Update script path and version variable

### DIFF
--- a/README.md
+++ b/README.md
@@ -112,7 +112,7 @@ Install and configure bitwarden on premise in docker-compose fashion.
   * [bitwarden_ssl_mode](#bitwarden_ssl_mode)
   * [bitwarden_ssl_provider](#bitwarden_ssl_provider)
   * [bitwarden_test_install_script](#bitwarden_test_install_script)
-  * [bitwarden_selfhost_version](#bitwarden_selfhost_version)
+  * [bitwarden_script_version](#bitwarden_script_version)
 * [Dependencies](#dependencies)
 * [License](#license)
 * [Author](#author)
@@ -220,12 +220,12 @@ A flag to disable downloading the `bitwarden.sh` script. Used in cases where the
 bitwarden_test_install_script: false
 ```
 
-### bitwarden_selfhost_version
+### bitwarden_script_version
 
 #### Default value
 
 ```YAML
-bitwarden_selfhost_version: v1.0.0
+bitwarden_script_version: v1.0.0
 ```
 
 ## Dependencies

--- a/README.md
+++ b/README.md
@@ -50,7 +50,7 @@ untrusted certs provided by the user, this role requires it to be trusted (signe
       vars:
         bitwarden_ssl_mode: provided
         bitwarden_nginx_cert_path: /path/to/ssl/cert
-        bitwarden_nginx_cert_key: /path/to/ssl/key
+        bitwarden_nginx_key_path: /path/to/ssl/key
 ```
 
 If an untrusted-user-provided-cert usecase is needed, it can be added with a new ssl_mode and corresponding inputs in 

--- a/README.md
+++ b/README.md
@@ -112,7 +112,7 @@ Install and configure bitwarden on premise in docker-compose fashion.
   * [bitwarden_ssl_mode](#bitwarden_ssl_mode)
   * [bitwarden_ssl_provider](#bitwarden_ssl_provider)
   * [bitwarden_test_install_script](#bitwarden_test_install_script)
-  * [bitwarden_version](#bitwarden_version)
+  * [bitwarden_selfhost_version](#bitwarden_selfhost_version)
 * [Dependencies](#dependencies)
 * [License](#license)
 * [Author](#author)
@@ -220,12 +220,12 @@ A flag to disable downloading the `bitwarden.sh` script. Used in cases where the
 bitwarden_test_install_script: false
 ```
 
-### bitwarden_version
+### bitwarden_selfhost_version
 
 #### Default value
 
 ```YAML
-bitwarden_version: v1.43.0
+bitwarden_selfhost_version: v1.0.0
 ```
 
 ## Dependencies

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -1,6 +1,6 @@
 ---
 # @var bitwarden_domain_name:description: Github tagged version of Bitwarden install script to use. Note that this has a different version in the script than the tag.
-bitwarden_version: "v1.43.0"
+bitwarden_selfhost_version: "v1.0.0"
 
 # @var bitwarden_domain_name:description: Domain name witch used for hole bitwarden setup
 bitwarden_domain_name: localhost

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -1,6 +1,6 @@
 ---
 # @var bitwarden_domain_name:description: Github tagged version of Bitwarden install script to use. Note that this has a different version in the script than the tag.
-bitwarden_selfhost_version: "v1.0.0"
+bitwarden_script_version: "v1.0.0"
 
 # @var bitwarden_domain_name:description: Domain name witch used for hole bitwarden setup
 bitwarden_domain_name: localhost

--- a/molecule/default/converge.yml
+++ b/molecule/default/converge.yml
@@ -2,7 +2,7 @@
 - name: Converge
   hosts: all
   vars:
-    bitwarden_version: "master"
+    bitwarden_selfhost_version: "master"
     # Use snakeoil certs installed in prepare step
     bitwarden_nginx_key_path: /etc/ssl/private/ssl-cert-snakeoil.key
     bitwarden_nginx_cert_path: /etc/ssl/certs/ssl-cert-snakeoil.pem

--- a/molecule/default/converge.yml
+++ b/molecule/default/converge.yml
@@ -2,7 +2,7 @@
 - name: Converge
   hosts: all
   vars:
-    bitwarden_selfhost_version: "master"
+    bitwarden_script_version: "master"
     # Use snakeoil certs installed in prepare step
     bitwarden_nginx_key_path: /etc/ssl/private/ssl-cert-snakeoil.key
     bitwarden_nginx_cert_path: /etc/ssl/certs/ssl-cert-snakeoil.pem

--- a/tasks/includes/prepare.yml
+++ b/tasks/includes/prepare.yml
@@ -13,10 +13,10 @@
     home: "{{ bitwarden_user_home }}"
   register: user
 
-- name: Download bitwarden.sh for {{ bitwarden_selfhost_version }}
+- name: Download bitwarden.sh for {{ bitwarden_script_version }}
   when: not bitwarden_test_install_script
   get_url:
-    url: https://raw.githubusercontent.com/bitwarden/self-host/{{ bitwarden_selfhost_version }}/bitwarden.sh
+    url: https://raw.githubusercontent.com/bitwarden/self-host/{{ bitwarden_script_version }}/bitwarden.sh
     dest: "{{ bitwarden_user_home }}/bitwarden.sh"
     mode: "0700"
     owner: "{{ bitwarden_user }}"

--- a/tasks/includes/prepare.yml
+++ b/tasks/includes/prepare.yml
@@ -13,10 +13,10 @@
     home: "{{ bitwarden_user_home }}"
   register: user
 
-- name: Download bitwarden.sh for {{ bitwarden_version }}
+- name: Download bitwarden.sh for {{ bitwarden_selfhost_version }}
   when: not bitwarden_test_install_script
   get_url:
-    url: https://raw.githubusercontent.com/bitwarden/server/{{ bitwarden_version }}/scripts/bitwarden.sh
+    url: https://raw.githubusercontent.com/bitwarden/self-host/{{ bitwarden_selfhost_version }}/bitwarden.sh
     dest: "{{ bitwarden_user_home }}/bitwarden.sh"
     mode: "0700"
     owner: "{{ bitwarden_user }}"


### PR DESCRIPTION
# Objective

Bitwarden has moved the install scripts to a separate repository for better versioning and maintaining.  This change updates the role to point to the new path as well as changes `bitwarden_version` variable to the bitwarden install script version number: `bitwarden_script_version`.